### PR TITLE
Update the HACS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ics_calendar
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 [![ics_calendar](https://img.shields.io/github/v/release/franc6/ics_calendar.svg?1)](https://github.com/franc6/ics_calendar)
 [![Coverage](https://codecov.io/gh/franc6/ics_calendar/branch/releases/graph/badge.svg)](https://app.codecov.io/gh/franc6/ics_calendar/branch/releases)
 ![Maintained:yes](https://img.shields.io/maintenance/yes/2022.svg)


### PR DESCRIPTION
I updated the HACS link in the badge from https://github.com/custom_components/hacs to https://github.com/hacs/integration