### PR TITLE
extend filter to handle events with none as description 

### DIFF
--- a/custom_components/ics_calendar/filter.py
+++ b/custom_components/ics_calendar/filter.py
@@ -1,7 +1,7 @@
 """Provide Filter class."""
 import re
 from ast import literal_eval
-from typing import List, Pattern
+from typing import List, Pattern, Optional
 
 from homeassistant.components.calendar import CalendarEvent
 
@@ -55,56 +55,58 @@ class Filter:
         return arr
 
     def _is_match(
-        self, summary: str, description: str, regexes: List[Pattern]
+        self, summary: str, description: Optional[str], regexes: List[Pattern]
     ) -> bool:
         """Indicates if the event matches the given list of regular expressions.
 
         :param summary: The event summary to examine
         :type summary: str
         :param description: The event description summary to examine
-        :type description: str
+        :type description: Optional[str]
         :param regexes: The regular expressions to match against
         :type regexes: List[]
         :return: True if the event matches the exclude filter
         :rtype: bool
         """
         for regex in regexes:
-            if regex.search(summary) or regex.search(description):
+            if regex.search(summary) or (
+                description and regex.search(description)
+            ):
                 return True
 
         return False
 
-    def _is_excluded(self, summary: str, description: str) -> bool:
+    def _is_excluded(self, summary: str, description: Optional[str]) -> bool:
         """Indicates if the event should be excluded
 
         :param summary: The event summary to examine
         :type summary: str
         :param description: The event description summary to examine
-        :type description: str
+        :type description: Optional[str]
         :return: True if the event matches the exclude filter
         :rtype: bool
         """
         return self._is_match(summary, description, self._exclude)
 
-    def _is_included(self, summary: str, description: str) -> bool:
+    def _is_included(self, summary: str, description: Optional[str]) -> bool:
         """Indicates if the event should be included.
 
         :param summary: The event summary to examine
         :type summary: str
         :param description: The event description summary to examine
-        :type description: str
+        :type description: Optional[str]
         :return: True if the event matches the include filter
         :rtype: bool
         """
         return self._is_match(summary, description, self._include)
 
-    def filter(self, summary: str, description: str) -> bool:
+    def filter(self, summary: str, description: Optional[str]) -> bool:
         """Checks if the event should be included or not.
 
         :param summary: The event summary to examine
         :type summary: str
         :param description: The event description summary to examine
-        :type description: str
+        :type description: Optional[str]
         :return: true if the event should be included, otherwise false
         :rtype: bool
         """

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,7 +6,7 @@ from custom_components.ics_calendar.filter import Filter
 
 
 @pytest.fixture()
-def calendar_event():
+def calendar_event() -> CalendarEvent:
     return CalendarEvent(
         summary="summary",
         start="start",
@@ -19,68 +19,55 @@ def calendar_event():
 class TestFilter:
     """Test the Filter class."""
 
-    def test_filter_empty(self):
-        """Test setting user agent"""
+    def test_filter_empty(self) -> None:
         filt = Filter("", "")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_event_empty(self, calendar_event):
-        """Test setting user agent"""
+    def test_filter_event_empty(self, calendar_event: CalendarEvent) -> None:
         filt = Filter("", "")
         assert filt.filter_event(calendar_event) is True
 
-    def test_filter_string_exclude_description(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude_description(self) -> None:
         filt = Filter("['crip']", "")
         assert filt.filter("summary", "description") is False
 
-    def test_filter_string_exclude_passes(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude_passes(self) -> None:
         filt = Filter("['blue']", "")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_string_exclude(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude(self) -> None:
         filt = Filter("['um']", "")
         assert filt.filter("summary", "description") is False
 
-    def test_filter_string_exclude_is_not_case_sensitive(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude_is_not_case_sensitive(self) -> None:
         filt = Filter("['um']", "")
         assert filt.filter("SUMMARY", "description") is False
 
-    def test_filter_string_exclude_but_string_include(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude_but_string_include(self) -> None:
         filt = Filter("['um']", "['crip']")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_string_exclude_but_regex_include(self):
-        """Test setting user agent"""
+    def test_filter_string_exclude_but_regex_include(self) -> None:
         filt = Filter("['um']", "['/crip/']")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_regex_exclude(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude(self) -> None:
         filt = Filter("['/um/']", "")
         assert filt.filter("summary", "description") is False
 
-    def test_filter_regex_exclude_but_string_include(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_but_string_include(self) -> None:
         filt = Filter("['/um/']", "['crip']")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_regex_exclude_but_regex_include(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_but_regex_include(self) -> None:
         filt = Filter("['/um/']", "['/crip/']")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_regex_exclude_ignore_case(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_ignore_case(self) -> None:
         filt = Filter("['/UM/i']", "")
         assert filt.filter("summary", "description") is False
 
-    def test_filter_regex_exclude_ignore_case_multiline(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_ignore_case_multiline(self) -> None:
         filt = Filter("['/CRiPT-$/im']", "")
         assert (
             filt.filter(
@@ -91,8 +78,7 @@ ion""",
             is False
         )
 
-    def test_filter_regex_exclude_ignore_case_multiline_dotall(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_ignore_case_multiline_dotall(self) -> None:
         filt = Filter("['/cript-.ion/sim']", "")
         assert (
             filt.filter(
@@ -103,8 +89,7 @@ ion""",
             is False
         )
 
-    def test_filter_regex_exclude_multiline(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_multiline(self) -> None:
         filt = Filter("['/cript-$/m']", "")
         assert (
             filt.filter(
@@ -115,8 +100,7 @@ ion""",
             is False
         )
 
-    def test_filter_regex_exclude_multiline_dotall(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_multiline_dotall(self) -> None:
         filt = Filter("['/cript-.ion/ms']", "")
         assert (
             filt.filter(
@@ -127,8 +111,7 @@ ion""",
             is False
         )
 
-    def test_filter_regex_exclude_dotall(self):
-        """Test setting user agent"""
+    def test_filter_regex_exclude_dotall(self) -> None:
         filt = Filter("['/cript-./s']", "")
         assert (
             filt.filter(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -92,12 +92,12 @@ ion""",
     def test_filter_regex_exclude_multiline(self) -> None:
         filt = Filter("['/cript-$/m']", "")
         assert (
-            filt.filter(
-                "summary",
-                """descript-
-ion""",
-            )
-            is False
+                filt.filter(
+                    "summary",
+                    """descript-
+    ion""",
+                )
+                is False
         )
 
     def test_filter_regex_exclude_multiline_dotall(self) -> None:
@@ -121,3 +121,7 @@ ion""",
             )
             is False
         )
+
+    def test_filter_with_description_none(self) -> None:
+        filt = Filter("['exclude']", "['include']")
+        assert filt.filter("summary", None) is True


### PR DESCRIPTION
CalendarEvents can have None as a description. This PR allows the
filter to handle such events by replacing None with an empty string.

In addition the filter tests are cleaned up a little bit.