### PR TITLE
Fix for multiple users

### DIFF
--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -233,12 +233,9 @@ class ICSCalendarData:
             self.name,
             device_data[CONF_URL],
             timedelta(minutes=device_data[CONF_DOWNLOAD_INTERVAL]),
-        )
-
-        self._calendar_data.set_headers(
             device_data[CONF_USERNAME],
             device_data[CONF_PASSWORD],
-            device_data[CONF_USER_AGENT],
+            device_data[CONF_USER_AGENT]
         )
 
     async def async_get_events(

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -23,7 +23,7 @@ class CalendarData:
     """
 
     def __init__(
-        self, logger: Logger, name: str, url: str, min_update_time: timedelta
+        self, logger: Logger, name: str, url: str, min_update_time: timedelta, username: str, password: str, agent: str
     ):
         """Construct CalendarData object.
 
@@ -43,6 +43,9 @@ class CalendarData:
         self.logger = logger
         self.name = name
         self.url = url
+        self.username = username
+        self.password = password
+        self.agent =  agent
 
     def download_calendar(self) -> bool:
         """Download the calendar data.
@@ -65,6 +68,11 @@ class CalendarData:
                 "%s: Downloading calendar data from: %s", self.name, self.url
             )
             try:
+                self.set_headers(
+                  self.username,
+                  self.password,
+                  self.agent,
+                )
                 with urlopen(self.url) as conn:
                     self._calendar_data = (
                         conn.read().decode().replace("\0", "")


### PR DESCRIPTION
Hi there, I have made for myself a small fix to be able to use config like this:

```
calendar:
  - platform: ics_calendar
    calendars:
      - name: "Name1"
        url: "http://caldavserver:8080/caldav/user1"
        include_all_day: True
        username: user1
        password: password1
      - name: "Susan"
        url: "http://caldavserver:8080/caldav/user2"
        include_all_day: True
        username: user2
        password: password2

```
With these changes I get two calendars in home assistant. Without it, one fails with Unauthorized message.
Possible fixes this: https://github.com/franc6/ics_calendar/issues/24

It basically sets the header before the urlopen