### PR TITLE
Revert "Fix for multiple users"

### DIFF
--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -233,9 +233,12 @@ class ICSCalendarData:
             self.name,
             device_data[CONF_URL],
             timedelta(minutes=device_data[CONF_DOWNLOAD_INTERVAL]),
+        )
+
+        self._calendar_data.set_headers(
             device_data[CONF_USERNAME],
             device_data[CONF_PASSWORD],
-            device_data[CONF_USER_AGENT]
+            device_data[CONF_USER_AGENT],
         )
 
     async def async_get_events(

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -23,7 +23,7 @@ class CalendarData:
     """
 
     def __init__(
-        self, logger: Logger, name: str, url: str, min_update_time: timedelta, username: str, password: str, agent: str
+        self, logger: Logger, name: str, url: str, min_update_time: timedelta
     ):
         """Construct CalendarData object.
 
@@ -43,9 +43,6 @@ class CalendarData:
         self.logger = logger
         self.name = name
         self.url = url
-        self.username = username
-        self.password = password
-        self.agent =  agent
 
     def download_calendar(self) -> bool:
         """Download the calendar data.
@@ -68,11 +65,6 @@ class CalendarData:
                 "%s: Downloading calendar data from: %s", self.name, self.url
             )
             try:
-                self.set_headers(
-                  self.username,
-                  self.password,
-                  self.agent,
-                )
                 with urlopen(self.url) as conn:
                     self._calendar_data = (
                         conn.read().decode().replace("\0", "")


### PR DESCRIPTION
Reverts franc6/ics_calendar#67

Looks like I was wrong; this needs a rather significantly different change, as moving the call to install_opener breaks the ability of the unit tests to install a different opener (e.g. one that doesn't make actual network connections).