### PR TITLE
Handle gzip-encoded responses

### DIFF
--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -1,5 +1,6 @@
 """Provide CalendarData class."""
 from datetime import timedelta
+from gzip import GzipFile
 from logging import Logger
 from threading import Lock
 from urllib.error import ContentTooShortError, HTTPError, URLError
@@ -125,8 +126,12 @@ class CalendarData:
                 if self._opener is not None:
                     install_opener(self._opener)
                 with urlopen(self.url) as conn:
+                    if 'Content-Encoding' in conn.headers and conn.headers['Content-Encoding'] == 'gzip':
+                       data = GzipFile(fileobj=conn).read()
+                    else:
+                       data = conn.read()
                     self._calendar_data = (
-                        conn.read().decode().replace("\0", "")
+                        data.decode().replace("\0", "")
                     )
         except HTTPError as http_error:
             self.logger.error(


### PR DESCRIPTION
Some servers in the wild will compress responses even if not requested by the client
via 'Accept-Encoding: gzip' headers.

For example, iCloud publishes ics files of public holidays in various jurisdictions:

```
% curl 'https://p18-calendars.icloud.com/holidays/ca_en.ics' -v 2>&1 | grep -P '^>.*|^< .*Content-Encoding:'
> GET /holidays/ca_en.ics HTTP/1.1
> Host: p18-calendars.icloud.com
> User-Agent: curl/7.79.1
> Accept: */*
>
< Content-Encoding: gzip
```

urllib does not automatically decompress such responses (for good reason), so this commit teaches ics_calendar to do so.