### PR TITLE
Fix #77

### DIFF
--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -159,7 +159,7 @@ class CalendarData:
             with CalendarData.opener_lock:
                 if self._opener is not None:
                     install_opener(self._opener)
-                with urlopen(self.url) as conn:
+                with urlopen(self._make_url()) as conn:
                     self._calendar_data = self._decode_data(conn)
         except HTTPError as http_error:
             self.logger.error(
@@ -182,3 +182,9 @@ class CalendarData:
             self.logger.error(
                 "%s: Failed to open url!", self.name, exc_info=True
             )
+
+    def _make_url(self):
+        now = hanow()
+        return self.url.replace("{year}", f"{now.year:04}").replace(
+            "{month}", f"{now.month:02}"
+        )


### PR DESCRIPTION
Added code to interpret "{year}" as the current 4 digit year, and "{month}" as the current 2 digit month.

Fixes #

Description of change:

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [] formatstyle.sh reports no errors
- [] All unit tests pass (test.sh)
- [] Code coverage has not decreased (test.sh)
