### PR TITLE
Fix for ha timezone required

### DIFF
--- a/custom_components/ics_calendar/parsers/parser_ics.py
+++ b/custom_components/ics_calendar/parsers/parser_ics.py
@@ -57,7 +57,7 @@ class ParserICS(ICalendarParser):
         :returns a list of events, or an empty list
         :rtype list[CalendarEvent]
         """
-        event_list = []
+        event_list: list[CalendarEvent] = []
 
         if self._calendar is not None:
             # ics 0.8 takes datetime not Arrow objects
@@ -69,13 +69,13 @@ class ParserICS(ICalendarParser):
             for event in self._calendar.timeline.included(ar_start, ar_end):
                 if event.all_day and not include_all_day:
                     continue
-                summary = ""
+                summary: str = ""
                 # ics 0.8 uses 'summary' reliably, older versions use 'name'
                 # if hasattr(event, "summary"):
                 #    summary = event.summary
                 # elif hasattr(event, "name"):
                 summary = event.name
-                calendar_event = CalendarEvent(
+                calendar_event: CalendarEvent = CalendarEvent(
                     summary=summary,
                     start=ParserICS.get_date(
                         event.begin, event.all_day, offset_hours
@@ -183,4 +183,8 @@ class ParserICS(ICalendarParser):
         #    return arw.date()
         #
         arw = arw.shift(hours=offset_hours)
-        return arw.datetime
+
+        return_value = arw.datetime
+        if return_value.tzinfo is None:
+            return_value = return_value.astimezone()
+        return return_value

--- a/custom_components/ics_calendar/parsers/parser_rie.py
+++ b/custom_components/ics_calendar/parsers/parser_rie.py
@@ -61,7 +61,7 @@ class ParserRIE(ICalendarParser):
         :returns a list of events, or an empty list
         :rtype list[CalendarEvent]
         """
-        event_list = []
+        event_list: list[CalendarEvent] = []
 
         if self._calendar is not None:
             for event in rie.of(self._calendar).between(
@@ -73,7 +73,7 @@ class ParserRIE(ICalendarParser):
                 if all_day and not include_all_day:
                     continue
 
-                calendar_event = CalendarEvent(
+                calendar_event: CalendarEvent = CalendarEvent(
                     summary=event.get("SUMMARY"),
                     start=start,
                     end=end,
@@ -109,8 +109,11 @@ class ParserRIE(ICalendarParser):
         if self._calendar is None:
             return None
 
-        temp_event = temp_start = temp_end = temp_all_day = None
-        end = now + timedelta(days=days)
+        temp_event: CalendarEvent = None
+        temp_start: date | datetime = None
+        temp_end: date | datetime = None
+        temp_all_day: bool = None
+        end: datetime = now + timedelta(days=days)
         for event in rie.of(self._calendar).between(
             now - timedelta(hours=offset_hours),
             end - timedelta(hours=offset_hours),
@@ -187,5 +190,9 @@ class ParserRIE(ICalendarParser):
         else:
             start = start + timedelta(hours=offset_hours)
             end = end + timedelta(hours=offset_hours)
+            if start.tzinfo is None:
+                start = start.astimezone()
+            if end.tzinfo is None:
+                end = end.astimezone()
 
         return start, end, all_day

--- a/custom_components/ics_calendar/parsers/parser_rie.py
+++ b/custom_components/ics_calendar/parsers/parser_rie.py
@@ -157,7 +157,7 @@ class ParserRIE(ICalendarParser):
         :rtype datetime
         """
         # Must use type here, since a datetime is also a date!
-        if type(date_time) == date:  # pylint: disable=C0123
+        if isinstance(date_time, date) and not isinstance(date_time, datetime):
             date_time = datetime.combine(date_time, datetime.min.time())
         return date_time.astimezone()
 

--- a/custom_components/ics_calendar/utility.py
+++ b/custom_components/ics_calendar/utility.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 
 def make_datetime(val):
     """Ensure val is a datetime, not a date."""
-    if type(val) == date:  # pylint: disable=C0123
+    if isinstance(val, date) and not isinstance(val, datetime):
         return datetime.combine(val, datetime.min.time()).astimezone()
     return val
 

--- a/tests/allday.ics.expected.json
+++ b/tests/allday.ics.expected.json
@@ -39,7 +39,7 @@
         "all_day": true,
         "summary": "7 All Day, 00:00:00 - 23:59:59, No Time Zone",
         "start": "2022-01-03",
-        "end": "2022-01-03"
+        "end": "2022-01-04"
     },
     {
         "all_day": true,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,14 +219,24 @@ def calendar_data(file_name):
 
 
 @pytest.fixture()
-def expected_data(file_name):
+def expected_name(file_name):
+    """Return {fileName}.
+
+    :param fileName: The base name of the file
+    :type fileName: str
+    """
+    return file_name
+
+
+@pytest.fixture()
+def expected_data(file_name, expected_name):
     """Return content of tests/{fileName}.expected.json.
 
     :param fileName: The base name of the file
     :type fileName: str
     """
     with open(
-        f"tests/{file_name}.expected.json", encoding="utf-8"
+        f"tests/{expected_name}.expected.json", encoding="utf-8"
     ) as file_handle:
         return json.loads(file_handle.read(), object_pairs_hook=datetime_hook)
 

--- a/tests/issue43-14.ics.expected.json
+++ b/tests/issue43-14.ics.expected.json
@@ -1,0 +1,8 @@
+[
+    {
+        "all_day": false,
+        "summary": "Recycling Collection",
+        "start": "2022-03-14T06:00:00-04:00",
+        "end": "2022-03-14T06:00:00-04:00"
+    }
+]

--- a/tests/issue43.ics.expected.json
+++ b/tests/issue43.ics.expected.json
@@ -1,8 +1,8 @@
 [
     {
-	"all_day": false,
-	"summary": "Recycling Collection",
-	"start": "2022-03-14T06:00:00-04:00",
-	"end": "2022-03-14T06:00:00-04:00"
+        "all_day": false,
+        "summary": "Recycling Collection",
+        "start": "2022-02-28T06:00:00-05:00",
+        "end": "2022-02-28T06:00:00-05:00"
     }
 ]

--- a/tests/issue45.ics.expected.json
+++ b/tests/issue45.ics.expected.json
@@ -1,8 +1,8 @@
 [
     {
-	"all_day": false,
-	"summary": "Recycling Collection",
-	"start": "2022-02-28T06:00:00-05:00",
-	"end": "2022-02-28T06:00:00-05:00"
+        "all_day": false,
+        "summary": "Recycling Collection",
+        "start": "2022-02-28T06:00:00-05:00",
+        "end": "2022-02-28T06:00:00-05:00"
     }
 ]

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -54,8 +54,8 @@ def _mocked_event():
     """Provide fixture to mock a single event."""
     return CalendarEvent(
         summary="Test event",
-        start=dtparser.parse("2022-01-03T00:00:00"),
-        end=dtparser.parse("2022-01-03T05:00:00"),
+        start=hadt.as_local(dtparser.parse("2022-01-03T00:00:00")),
+        end=hadt.as_local(dtparser.parse("2022-01-03T05:00:00")),
         location="Test location",
         description="Test description",
     )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,6 @@
 """Test the Filter class."""
 import pytest
+from dateutil import parser as dtparser
 from homeassistant.components.calendar import CalendarEvent
 
 from custom_components.ics_calendar.filter import Filter
@@ -10,8 +11,8 @@ def calendar_event() -> CalendarEvent:
     """Fixture to return a CalendarEvent."""
     return CalendarEvent(
         summary="summary",
-        start="start",
-        end="start",
+        start=dtparser.parse("2020-01-01T0:00:00").astimezone(),
+        end=dtparser.parse("2020-01-01T0:00:00").astimezone(),
         location="location",
         description="description",
     )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -271,12 +271,12 @@ class TestParsers:
             "ics_parser",
         ],
     )
-    @pytest.mark.parametrize("file_name", ["issue45.ics"])
+    @pytest.mark.parametrize("file_name", ["issue43.ics"])
     def test_issue_forty_three_two_days(
         self, parser, calendar_data, expected_data
     ):
         """Test if still fixed, issue 43."""
-        now = dtparser.parse("2022-02-28T06:00:00-05:00")
+        now = dtparser.parse("2022-02-28T06:00:00-04:00")
         parser.set_content(calendar_data)
         current_event = parser.get_current_event(True, now, 2)
         event_list = [current_event]
@@ -291,11 +291,12 @@ class TestParsers:
         ],
     )
     @pytest.mark.parametrize("file_name", ["issue43.ics"])
+    @pytest.mark.parametrize("expected_name", ["issue43-14.ics"])
     def test_issue_forty_three_fourteen_days(
         self, parser, calendar_data, expected_data
     ):
         """Test if still fixed, issue 43."""
-        now = dtparser.parse("2022-03-01T06:00:00-05:00")
+        now = dtparser.parse("2022-03-01T06:00:00-04:00")
         parser.set_content(calendar_data)
         current_event = parser.get_current_event(True, now, 14)
         event_list = [current_event]


### PR DESCRIPTION
Fixes #90

Description of change:
Changes to accommodate the new HA requirement that for events which are not all day, the event must have a time zone. This is wrong from the perspective of the calendar, since the calendar events can be "floating", so this forces those events to have the time zone, not of the person/computer viewing the event, but the time zone of the server.  This is insane, but HA requires it. :(

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
