### PR TITLE
Add connection timeout conf option

### DIFF
--- a/custom_components/ics_calendar/__init__.py
+++ b/custom_components/ics_calendar/__init__.py
@@ -31,6 +31,7 @@ CONF_DOWNLOAD_INTERVAL = "download_interval"
 CONF_USER_AGENT = "user_agent"
 CONF_OFFSET_HOURS = "offset_hours"
 CONF_ACCEPT_HEADER = "accept_header"
+CONF_CONNECTION_TIMEOUT = "connection_timeout"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -81,6 +82,9 @@ CONFIG_SCHEMA = vol.Schema(
                                     vol.Optional(
                                         CONF_ACCEPT_HEADER, default=""
                                     ): cv.string,
+                                    vol.Optional(
+                                        CONF_CONNECTION_TIMEOUT, default=None
+                                    ): cv.socket_timeout,
                                 }
                             )
                         ]

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -31,6 +31,7 @@ from homeassistant.util.dt import now as hanow
 from . import (
     CONF_ACCEPT_HEADER,
     CONF_CALENDARS,
+    CONF_CONNECTION_TIMEOUT,
     CONF_DAYS,
     CONF_DOWNLOAD_INTERVAL,
     CONF_INCLUDE_ALL_DAY,
@@ -91,6 +92,7 @@ def setup_platform(
             CONF_INCLUDE: calendar.get(CONF_INCLUDE),
             CONF_OFFSET_HOURS: calendar.get(CONF_OFFSET_HOURS),
             CONF_ACCEPT_HEADER: calendar.get(CONF_ACCEPT_HEADER),
+            CONF_CONNECTION_TIMEOUT: calendar.get(CONF_CONNECTION_TIMEOUT)
         }
         device_id = f"{device_data[CONF_NAME]}"
         entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
@@ -208,6 +210,7 @@ class ICSCalendarData:  # pylint: disable=R0902
             self.name,
             device_data[CONF_URL],
             timedelta(minutes=device_data[CONF_DOWNLOAD_INTERVAL]),
+            device_data[CONF_CONNECTION_TIMEOUT]
         )
 
         self._calendar_data.set_headers(

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -92,7 +92,7 @@ def setup_platform(
             CONF_INCLUDE: calendar.get(CONF_INCLUDE),
             CONF_OFFSET_HOURS: calendar.get(CONF_OFFSET_HOURS),
             CONF_ACCEPT_HEADER: calendar.get(CONF_ACCEPT_HEADER),
-            CONF_CONNECTION_TIMEOUT: calendar.get(CONF_CONNECTION_TIMEOUT)
+            CONF_CONNECTION_TIMEOUT: calendar.get(CONF_CONNECTION_TIMEOUT),
         }
         device_id = f"{device_data[CONF_NAME]}"
         entity_id = generate_entity_id(ENTITY_ID_FORMAT, device_id, hass=hass)
@@ -210,7 +210,7 @@ class ICSCalendarData:  # pylint: disable=R0902
             self.name,
             device_data[CONF_URL],
             timedelta(minutes=device_data[CONF_DOWNLOAD_INTERVAL]),
-            device_data[CONF_CONNECTION_TIMEOUT]
+            device_data[CONF_CONNECTION_TIMEOUT],
         )
 
         self._calendar_data.set_headers(

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -28,7 +28,12 @@ class CalendarData:
     opener_lock = Lock()
 
     def __init__(
-        self, logger: Logger, name: str, url: str, min_update_time: timedelta, connection_timeout: float
+        self,
+        logger: Logger,
+        name: str,
+        url: str,
+        min_update_time: timedelta,
+        connection_timeout: float,
     ):
         """Construct CalendarData object.
 

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -28,7 +28,7 @@ class CalendarData:
     opener_lock = Lock()
 
     def __init__(
-        self, logger: Logger, name: str, url: str, min_update_time: timedelta
+        self, logger: Logger, name: str, url: str, min_update_time: timedelta, connection_timeout: float
     ):
         """Construct CalendarData object.
 
@@ -41,6 +41,8 @@ class CalendarData:
         :param min_update_time: The minimum time between downloading data from
             the URL when requested
         :type min_update_time: timedelta
+        :param connection_timeout: The timeout in seconds for blocking operations like the connection attempt
+        :type connection_timeout: float
         """
         self._calendar_data = None
         self._last_download = None
@@ -49,6 +51,7 @@ class CalendarData:
         self.logger = logger
         self.name = name
         self.url = url
+        self.connection_timeout = connection_timeout
 
     def download_calendar(self) -> bool:
         """Download the calendar data.
@@ -167,7 +170,7 @@ class CalendarData:
             with CalendarData.opener_lock:
                 if self._opener is not None:
                     install_opener(self._opener)
-                with urlopen(self._make_url()) as conn:
+                with urlopen(self._make_url(), timeout=self.connection_timeout) as conn:
                     self._calendar_data = self._decode_data(conn)
         except HTTPError as http_error:
             self.logger.error(

--- a/tests/test_calendardata.py
+++ b/tests/test_calendardata.py
@@ -2,6 +2,9 @@
 import email
 from datetime import timedelta
 from io import BytesIO
+from socket import (  # type: ignore[attr-defined]  # private, not in typeshed
+    _GLOBAL_DEFAULT_TIMEOUT,
+)
 from unittest.mock import patch
 from urllib.error import ContentTooShortError, HTTPError, URLError
 from urllib.request import HTTPHandler, build_opener, install_opener
@@ -98,6 +101,14 @@ class MockHTTPHandlerURLError(HTTPHandler):
     def http_open(self, req):
         """Provide http_open to raise exception."""
         raise URLError("bad url")
+
+
+class MockHTTPHandlerURLErrorTimeout(HTTPHandler):
+    """Mock HTTPHandler with an URLError."""
+
+    def http_open(self, req):
+        """Provide http_open to raise exception."""
+        raise URLError("<urlopen error timed out>")
 
 
 class MockHTTPHandlerError(HTTPHandler):
@@ -202,7 +213,11 @@ class TestCalendarData:
     def test_set_headers_none(self, logger):
         """Test set_headers without user name, password, or user agent."""
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("", "", "", "")
 
@@ -214,7 +229,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("", "", "", "text/calendar")
 
@@ -226,7 +245,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("", "", "Mozilla/5.0", "")
 
@@ -238,7 +261,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("username", "password", "", "")
 
@@ -250,7 +277,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("username", "password", "Mozilla/5.0", "")
 
@@ -262,7 +293,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers("username", "password", "", "text/calendar")
 
@@ -274,7 +309,11 @@ class TestCalendarData:
         means checking the implementation.
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         calendar_data.set_headers(
             "username", "password", "Mozilla/5.0", "text/calendar"
@@ -283,7 +322,11 @@ class TestCalendarData:
     def test_get(self, logger):
         """Test get method retrieves cached data."""
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         set_calendar_data(calendar_data, CALENDAR_DATA)
         assert calendar_data.get() == CALENDAR_DATA
@@ -294,7 +337,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandler)
         install_opener(opener)
@@ -311,7 +358,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_TEMPLATE_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_TEMPLATE_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerInterpretTemplates)
         install_opener(opener)
@@ -324,7 +375,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandler)
         calendar_data._opener = opener  # pylint: disable=W0212
@@ -337,7 +392,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerUTF8BOM)
         install_opener(opener)
@@ -350,7 +409,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerUTF16BOMBE)
         install_opener(opener)
@@ -363,7 +426,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerUTF16BOMLE)
         install_opener(opener)
@@ -376,7 +443,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerBadUTF)
         install_opener(opener)
@@ -389,7 +460,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPGzipHandler)
         install_opener(opener)
@@ -402,7 +477,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPGzipHandlerBadGzip)
         install_opener(opener)
@@ -415,7 +494,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPGzipHandlerBadDeflate)
         install_opener(opener)
@@ -428,7 +511,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerContentTooShortError)
         install_opener(opener)
@@ -441,7 +528,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerHTTPError)
         install_opener(opener)
@@ -454,9 +545,30 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerURLError)
+        install_opener(opener)
+        calendar_data.download_calendar()
+        assert calendar_data.get() is None
+
+    def test_download_calendar_socket_timeout_URLError(self, logger):
+        """Test that None is cached if the connection times out, which returns URLError.
+
+        This test relies on the success of test_get!
+        """
+        calendar_data = CalendarData(
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            connection_timeout=2.0,
+        )
+        opener = build_opener(MockHTTPHandlerURLErrorTimeout)
         install_opener(opener)
         calendar_data.download_calendar()
         assert calendar_data.get() is None
@@ -467,7 +579,11 @@ class TestCalendarData:
         This test relies on the success of test_get!
         """
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandlerError)
         install_opener(opener)
@@ -487,7 +603,11 @@ class TestCalendarData:
             dtparser.parse("2022-01-01T00:05:05"),
         ]
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandler)
         install_opener(opener)
@@ -512,7 +632,11 @@ class TestCalendarData:
             dtparser.parse("2022-01-01T00:04:59"),
         ]
         calendar_data = CalendarData(
-            logger, CALENDAR_NAME, TEST_URL, timedelta(minutes=5)
+            logger,
+            CALENDAR_NAME,
+            TEST_URL,
+            timedelta(minutes=5),
+            _GLOBAL_DEFAULT_TIMEOUT,
         )
         opener = build_opener(MockHTTPHandler)
         install_opener(opener)


### PR DESCRIPTION
I ran into issues with the component getting completely stuck and preventing all calendars from updating if the connection never completed. The default timeout is no timeout, so the data lock would never be released, and all calendars would stop updating. This PR adds a configuration parameter to change this, which defaults to "no timeout" for backwards compatibility.