### PR TITLE
Fixes #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Key | Type | Required | Description
 `user_agent` | `string` | `False` | Allows setting the User-agent header.  Only specify this if your server rejects the normal python user-agent string.  You must set the entire and exact user agent string here.
 
 #### Download Interval
-The download interval should be a multiple of 15 at this time.  This is so downloads coincide with Home Assistant's update interval for the calendar entities. Setting a value smaller than 15 will increase both CPU and memory usage.  Higher values will reduce CPU usage.  The default of 15 is to keep the same behavior with regards to downloads as in the past.
+The download interval should be a multiple of 15 at this time.  This is so downloads coincide with Home Assistant's update interval for the calendar entities. Setting a value smaller than 15 will increase both CPU and memory usage.  Higher values will reduce CPU usage.  The default of 15 is to keep the same behavior with regards to downloads as in the past.  If you check the logs, the actual download may take place up to 2 seconds after it was requested.  For users that have many calendars all on the same server, this will reduce the server load.
 
 #### Offset Hours
 This feature is to aid with calendars that present incorrect times.  If your calendar has an incorrect time, e.g. it lists your local time, but indicates that it's the time in UTC, this can be used to correct for your local time.  This affects all events, except all day events.  All day events do not include time information, and so the offset will not be applied.  Use a positive number to add hours to the time, and a negative number to subtract hours from the time.

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -1,7 +1,7 @@
 """Support for ICS Calendar."""
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 
 # import homeassistant.helpers.config_validation as cv
 # import voluptuous as vol
@@ -183,6 +183,29 @@ class ICSCalendarEntity(CalendarEntity):
             if self._event
             else False
         }
+
+    async def async_create_event(self, **kwargs: Any):
+        """Raise error, this is a read-only calendar."""
+        raise NotImplementedError()
+
+    async def async_delete_event(
+        self,
+        uid: str,
+        recurrence_id: str | None = None,
+        recurrence_range: str | None = None,
+    ) -> None:
+        """Raise error, this is a read-only calendar."""
+        raise NotImplementedError()
+
+    async def async_update_event(
+        self,
+        uid: str,
+        event: dict[str, Any],
+        recurrence_id: str | None = None,
+        recurrence_range: str | None = None,
+    ) -> None:
+        """Raise error, this is a read-only calendar."""
+        raise NotImplementedError()
 
 
 class ICSCalendarData:  # pylint: disable=R0902

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -1,8 +1,10 @@
 """Provide CalendarData class."""
+import time
 import zlib
 from datetime import timedelta
 from gzip import BadGzipFile, GzipFile
 from logging import Logger
+from random import uniform
 from socket import (  # type: ignore[attr-defined]  # private, not in typeshed
     _GLOBAL_DEFAULT_TIMEOUT,
 )
@@ -20,7 +22,7 @@ from urllib.request import (
 from homeassistant.util.dt import now as hanow
 
 
-class CalendarData:
+class CalendarData:  # pylint: disable=R0902
     """CalendarData class.
 
     The CalendarData class is used to download and cache calendar data from a
@@ -57,6 +59,10 @@ class CalendarData:
         self.name = name
         self.url = url
         self.connection_timeout = _GLOBAL_DEFAULT_TIMEOUT
+        # set a random sleep between 0.001 seconds & 2.000 seconds to
+        # reduce server load, particularly if lots of calendars all use the
+        # same server.
+        self._sleep_time = uniform(0.001, 2.000)
 
     def download_calendar(self) -> bool:
         """Download the calendar data.
@@ -78,6 +84,7 @@ class CalendarData:
             self.logger.debug(
                 "%s: Downloading calendar data from: %s", self.name, self.url
             )
+            self._wait_for_server()
             self._download_data()
             return self._calendar_data is not None
 
@@ -143,6 +150,10 @@ class CalendarData:
         :type connection_timeout: float
         """
         self.connection_timeout = connection_timeout
+
+    def _wait_for_server(self):
+        """Sleep for self._sleep_time to reduce server load."""
+        time.sleep(self._sleep_time)
 
     def _decode_data(self, conn):
         if (

--- a/custom_components/ics_calendar/const.py
+++ b/custom_components/ics_calendar/const.py
@@ -1,5 +1,5 @@
 """Constants for ics_calendar platform."""
-VERSION = "4.1.0"
+VERSION = "4.2.0"
 DOMAIN = "ics_calendar"
 UPGRADE_URL = (
     "https://github.com/franc6/ics_calendar/blob/releases/"

--- a/custom_components/ics_calendar/manifest.json
+++ b/custom_components/ics_calendar/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/franc6/ics_calendar/issues",
     "requirements": ["ics>=0.7.2", "recurring_ical_events>=2.0.2", "icalendar>=5.0.4"],
-    "version": "4.1.0"
+    "version": "4.2.0"
 }

--- a/info.md
+++ b/info.md
@@ -35,6 +35,7 @@ Key | Type | Required | Description
 `name` | `string` | `True` | A name for the calendar
 `url` | `string` | `True` | The URL of the remote calendar
 `accept_header` | `string` | An accept header for servers that are misconfigured, default is not set
+`connection_timeout` | `float` | `None` | Sets a timeout for the connection to donwload the calendar.  Use this if you have frequent connection issues with a calendar
 `days` | `positive integer` | `False` | The number of days to look ahead (only affects the attributes of the calendar entity), default is 1
 `download_interval` | `positive integer` | `False` | The time between downloading new calendar data, in minutes, default is 15
 `exclude` | `string` | `False` | Allows for filtering of events, see below
@@ -48,7 +49,7 @@ Key | Type | Required | Description
 `user_agent` | `string` | `False` | Allows setting the User-agent header.  Only specify this if your server rejects the normal python user-agent string.  You must set the entire and exact user agent string here.
 
 #### Download Interval
-The download interval should be a multiple of 15 at this time.  This is so downloads coincide with Home Assistant's update interval for the calendar entities. Setting a value smaller than 15 will increase both CPU and memory usage.  Higher values will reduce CPU usage.  The default of 15 is to keep the same behavior with regards to downloads as in the past.
+The download interval should be a multiple of 15 at this time.  This is so downloads coincide with Home Assistant's update interval for the calendar entities. Setting a value smaller than 15 will increase both CPU and memory usage.  Higher values will reduce CPU usage.  The default of 15 is to keep the same behavior with regards to downloads as in the past.  If you check the logs, the actual download may take place up to 2 seconds after it was requested.  For users that have many calendars all on the same server, this will reduce the server load.
 
 #### Offset Hours
 This feature is to aid with calendars that present incorrect times.  If your calendar has an incorrect time, e.g. it lists your local time, but indicates that it's the time in UTC, this can be used to correct for your local time.  This affects all events, except all day events.  All day events do not include time information, and so the offset will not be applied.  Use a positive number to add hours to the time, and a negative number to subtract hours from the time.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
-pytest>=7.2.1
+pytest==7.4.3
 pytest-cov==4.1.0
-pytest-homeassistant-custom-component>=0.13.66
+pytest-homeassistant-custom-component>=0.13.89
 pytest-helpers-namespace==2021.12.29
 pytest-asyncio
 pytest-aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-icalendar >= 5.0.8
+icalendar >= 5.0.11
 python-dateutil >= 2.8.2
 pytz >= 2023.3.post1
-recurring_ical_events >= 2.0.2
+recurring_ical_events >= 2.1.2
 ics >= 0.7.2
 arrow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures and helpers for tests."""
 import json
 import logging
+import time
 from http import HTTPStatus
 
 import pytest
@@ -293,6 +294,20 @@ def expected_data(file_name, expected_name):
 def logger():
     """Provide autouse fixture for logger."""
     return logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def sleepless(monkeypatch):
+    """Disable time.sleep() calls."""
+
+    def sleep(seconds):
+        pass
+
+    monkeypatch.setattr(
+        time,
+        "sleep",
+        sleep,
+    )
 
 
 @pytest.helpers.register

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -7,6 +7,7 @@ import pytest
 from dateutil import parser as dtparser
 from homeassistant.components.calendar import CalendarEvent
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as hadt
@@ -856,3 +857,41 @@ class TestCalendar:
 
         events = await get_api_events("calendar.noallday")
         assert len(events) == 0
+
+    @patch(
+        "custom_components.ics_calendar.calendardata.CalendarData.download_calendar",
+        return_value=False,
+    )
+    @patch(
+        "custom_components.ics_calendar.calendardata.CalendarData.get",
+        return_value=_mocked_calendar_data("tests/allday.ics"),
+    )
+    @patch(
+        "custom_components.ics_calendar.parsers.parser_rie.ParserRIE"
+        ".get_event_list",
+        return_value=_mocked_event_list(),
+    )
+    async def test_create_event_raises_error(
+        self,
+        mock_event_list,
+        mock_get,
+        mock_download,
+        hass,
+        noallday_config,
+    ):
+        """Test that create_event raises an error."""
+        assert await async_setup_component(hass, DOMAIN, noallday_config)
+        await hass.async_block_till_done()
+
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                "calendar",
+                "create_event",
+                {
+                    "start_date_time": "2024-01-15T12:00:00+00:00",
+                    "end_date_time": "2024-01-15T12:01:00+00:00",
+                    "summary": "Test event",
+                },
+                target={"entity_id": "calendar.noallday"},
+                blocking=True,
+            )

--- a/tests/test_calendardata.py
+++ b/tests/test_calendardata.py
@@ -2,8 +2,6 @@
 import email
 from datetime import timedelta
 from io import BytesIO
-
-# )
 from unittest.mock import patch
 from urllib.error import ContentTooShortError, HTTPError, URLError
 from urllib.request import HTTPHandler, build_opener, install_opener


### PR DESCRIPTION
Add code to sleep for a short time (from 0.001 to 2.000 seconds) before downloading data.  This time will be consistent for each calendar.  See issue #117 for justification.

Fixes #117

Description of change:

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
