### PR TITLE
Fix comparison of exclude and include

### DIFF
--- a/custom_components/ics_calendar/config_flow.py
+++ b/custom_components/ics_calendar/config_flow.py
@@ -148,7 +148,7 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
         """Calendar Options step for ConfigFlow."""
         errors = {}
         if user_input is not None:
-            if user_input[CONF_EXCLUDE] != user_input[CONF_INCLUDE]:
+            if user_input[CONF_EXCLUDE] == user_input[CONF_INCLUDE]:
                 errors[CONF_EXCLUDE] = "exclude_include_cannot_be_the_same"
             if user_input[CONF_DOWNLOAD_INTERVAL] < 15:
                 _LOGGER.error("download_interval_too_small error")


### PR DESCRIPTION
Description of change:

Fix the comparison of exclude and include filters. Currently this would trigger when the exclude and include filter are different but the error implies that the opposite is meant.

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [x] formatstyle.sh reports no errors
- [x] All unit tests pass (test.sh)
- [x] Code coverage has not decreased (test.sh)
