### PR TITLE
Fix #151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 - Fixed #149 Thanks, @jpbede!
 - Added German Translation by @mbenecke
 - Fixed #148
+- Fixed #151 Thanks to everyone who reported details on this one!
+
+### Breaking Change
+If you installed 5.0.0, you'll probably need to re-enable the YAML configuration, remove all entities from ICS Calendar (note: this might mean going to Settings | Devices & entities | Entities, and filtering for "calendar.") and then restart HA.  You can then disable your YAML configuration again.
 
 ## 5.0.0 2024/09/10
 - Fixed #117 Made sure the global download lock blocks and ensures min_update_time. (@agroszer)

--- a/custom_components/ics_calendar/__init__.py
+++ b/custom_components/ics_calendar/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_ACCEPT_HEADER,
+    CONF_ADV_CONNECT_OPTS,
     CONF_CALENDARS,
     CONF_CONNECTION_TIMEOUT,
     CONF_DAYS,
@@ -32,6 +33,8 @@ from .const import (
     CONF_INCLUDE_ALL_DAY,
     CONF_OFFSET_HOURS,
     CONF_PARSER,
+    CONF_REQUIRES_AUTH,
+    CONF_SET_TIMEOUT,
     CONF_USER_AGENT,
     DOMAIN,
 )
@@ -89,8 +92,8 @@ CONFIG_SCHEMA = vol.Schema(
                                         CONF_ACCEPT_HEADER, default=""
                                     ): cv.string,
                                     vol.Optional(
-                                        CONF_CONNECTION_TIMEOUT, default=None
-                                    ): cv.socket_timeout,
+                                        CONF_CONNECTION_TIMEOUT, default=300
+                                    ): cv.positive_float,
                                 }
                             )
                         ]
@@ -205,15 +208,19 @@ def add_missing_defaults(  # noqa: C901,R701 # pylint: disable=R0912,R0915
     data = {}
     data[CONF_NAME] = entry.data[CONF_NAME]
     data[CONF_URL] = entry.data[CONF_URL]
+    data[CONF_ADV_CONNECT_OPTS] = False
+    data[CONF_REQUIRES_AUTH] = False
     if CONF_INCLUDE_ALL_DAY in entry.data:
         data[CONF_INCLUDE_ALL_DAY] = entry.data[CONF_INCLUDE_ALL_DAY]
     else:
         data[CONF_INCLUDE_ALL_DAY] = False
     if CONF_USERNAME in entry.data:
+        data[CONF_REQUIRES_AUTH] = True
         data[CONF_USERNAME] = entry.data[CONF_USERNAME]
     else:
         data[CONF_USERNAME] = ""
     if CONF_PASSWORD in entry.data:
+        data[CONF_REQUIRES_AUTH] = True
         data[CONF_PASSWORD] = entry.data[CONF_PASSWORD]
     else:
         data[CONF_PASSWORD] = ""
@@ -234,6 +241,7 @@ def add_missing_defaults(  # noqa: C901,R701 # pylint: disable=R0912,R0915
     else:
         data[CONF_DOWNLOAD_INTERVAL] = 15
     if CONF_USER_AGENT in entry.data:
+        data[CONF_ADV_CONNECT_OPTS] = True
         data[CONF_USER_AGENT] = entry.data[CONF_USER_AGENT]
     else:
         data[CONF_USER_AGENT] = ""
@@ -250,13 +258,17 @@ def add_missing_defaults(  # noqa: C901,R701 # pylint: disable=R0912,R0915
     else:
         data[CONF_OFFSET_HOURS] = 0
     if CONF_ACCEPT_HEADER in entry.data:
+        data[CONF_ADV_CONNECT_OPTS] = True
         data[CONF_ACCEPT_HEADER] = entry.data[CONF_ACCEPT_HEADER]
     else:
         data[CONF_ACCEPT_HEADER] = ""
     if CONF_CONNECTION_TIMEOUT in entry.data:
+        data[CONF_ADV_CONNECT_OPTS] = True
+        data[CONF_SET_TIMEOUT] = True
         data[CONF_CONNECTION_TIMEOUT] = entry.data[CONF_CONNECTION_TIMEOUT]
     else:
-        data[CONF_CONNECTION_TIMEOUT] = None
+        data[CONF_SET_TIMEOUT] = False
+        data[CONF_CONNECTION_TIMEOUT] = 300.0
 
     return data
 

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_INCLUDE_ALL_DAY,
     CONF_OFFSET_HOURS,
     CONF_PARSER,
+    CONF_SET_TIMEOUT,
     CONF_USER_AGENT,
     DOMAIN,
 )
@@ -143,9 +144,9 @@ class ICSCalendarEntity(CalendarEntity):
         )
         self.data = ICSCalendarData(device_data)
         self.entity_id = entity_id
-        self.unique_id = unique_id
+        self._attr_unique_id = f"ICSCalendar.{unique_id}"
         self._event = None
-        self._name = device_data[CONF_NAME]
+        self._attr_name = device_data[CONF_NAME]
         self._last_call = None
 
     @property
@@ -158,12 +159,7 @@ class ICSCalendarEntity(CalendarEntity):
         return self._event
 
     @property
-    def name(self):
-        """Return the name of the calendar."""
-        return self._name
-
-    @property
-    def should_poll(self):
+    def should_poll(self) -> bool:
         """Indicate if the calendar should be polled.
 
         If the last call to update or get_api_events was not within the minimum
@@ -269,7 +265,15 @@ class ICSCalendarData:  # pylint: disable=R0902
             device_data[CONF_ACCEPT_HEADER],
         )
 
-        self._calendar_data.set_timeout(device_data[CONF_CONNECTION_TIMEOUT])
+        if CONF_SET_TIMEOUT in device_data:
+            if device_data[CONF_SET_TIMEOUT]:
+                self._calendar_data.set_timeout(
+                    device_data[CONF_CONNECTION_TIMEOUT]
+                )
+        else:
+            self._calendar_data.set_timeout(
+                device_data[CONF_CONNECTION_TIMEOUT]
+            )
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -270,10 +270,6 @@ class ICSCalendarData:  # pylint: disable=R0902
                 self._calendar_data.set_timeout(
                     device_data[CONF_CONNECTION_TIMEOUT]
                 )
-        else:
-            self._calendar_data.set_timeout(
-                device_data[CONF_CONNECTION_TIMEOUT]
-            )
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime

--- a/custom_components/ics_calendar/config_flow.py
+++ b/custom_components/ics_calendar/config_flow.py
@@ -20,21 +20,20 @@ from homeassistant.helpers.selector import selector
 
 from . import (
     CONF_ACCEPT_HEADER,
+    CONF_ADV_CONNECT_OPTS,
     CONF_CONNECTION_TIMEOUT,
     CONF_DAYS,
     CONF_DOWNLOAD_INTERVAL,
     CONF_INCLUDE_ALL_DAY,
     CONF_OFFSET_HOURS,
     CONF_PARSER,
+    CONF_REQUIRES_AUTH,
+    CONF_SET_TIMEOUT,
     CONF_USER_AGENT,
 )
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_REQUIRES_AUTH = "requires_auth"
-CONF_ADV_CONNECT_OPTS = "advanced_connection_options"
-CONF_SET_TIMEOUT = "set_connection_timeout"
 
 CALENDAR_NAME_SCHEMA = vol.Schema(
     {
@@ -81,7 +80,7 @@ ADVANCED_CONNECT_OPTS_SCHEMA = vol.Schema(
 )
 
 TIMEOUT_OPTS_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_CONNECTION_TIMEOUT, default=None): cv.positive_int}
+    {vol.Optional(CONF_CONNECTION_TIMEOUT, default=None): cv.positive_float}
 )
 
 

--- a/custom_components/ics_calendar/const.py
+++ b/custom_components/ics_calendar/const.py
@@ -1,6 +1,6 @@
 """Constants for ics_calendar platform."""
 
-VERSION = "5.0.0"
+VERSION = "5.0.1"
 DOMAIN = "ics_calendar"
 
 CONF_DEVICE_ID = "device_id"
@@ -13,3 +13,6 @@ CONF_USER_AGENT = "user_agent"
 CONF_OFFSET_HOURS = "offset_hours"
 CONF_ACCEPT_HEADER = "accept_header"
 CONF_CONNECTION_TIMEOUT = "connection_timeout"
+CONF_SET_TIMEOUT = "set_connection_timeout"
+CONF_REQUIRES_AUTH = "requires_auth"
+CONF_ADV_CONNECT_OPTS = "advanced_connection_options"


### PR DESCRIPTION
Since we already have a value to indicate if timeout is set, use that and change connection_timeout to be a positive_float.  This fixes the serialization issues, which led to calendars disappearing on restart of HA, and other kinds of havoc.

Also fixed name and unique id properties

Fixes #151

Description of change:

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
