### PR TITLE
Fix #170

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [ ] Add unit tests for setup entry points in ics_calendar/__init__.py
 
 ## General
-- [ ] Figure out how to get entries named something other than "ICS Calendar" when looking at separate entries in Setup
+- [X] Figure out how to get entries named something other than "ICS Calendar" when looking at separate entries in Setup
 
 ## UI Config
 - [ ] Revamp UI config, especially for URLs (see #133, #116, #169)

--- a/custom_components/ics_calendar/config_flow.py
+++ b/custom_components/ics_calendar/config_flow.py
@@ -214,7 +214,10 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_auth_opts()
                 if user_input.get(CONF_ADV_CONNECT_OPTS, False):
                     return await self.async_step_adv_connect_opts()
-                return self.async_create_entry(title="", data=self.data)
+                return self.async_create_entry(
+                    title=self.data[CONF_NAME],
+                    data=self.data,
+                )
 
         return self.async_show_form(
             step_id="connect_opts",
@@ -230,7 +233,10 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
             self.data.update(user_input)
             if self.data.get(CONF_ADV_CONNECT_OPTS, False):
                 return await self.async_step_adv_connect_opts()
-            return self.async_create_entry(title="", data=self.data)
+            return self.async_create_entry(
+                title=self.data[CONF_NAME],
+                data=self.data,
+            )
 
         return self.async_show_form(
             step_id="auth_opts", data_schema=AUTH_OPTS_SCHEMA
@@ -247,7 +253,10 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.data.update(user_input)
                 if user_input.get(CONF_SET_TIMEOUT, False):
                     return await self.async_step_timeout_opts()
-                return self.async_create_entry(title="", data=self.data)
+                return self.async_create_entry(
+                    title=self.data[CONF_NAME],
+                    data=self.data,
+                )
 
         return self.async_show_form(
             step_id="adv_connect_opts",
@@ -264,7 +273,10 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 self.data.update(user_input)
-                return self.async_create_entry(title="", data=self.data)
+                return self.async_create_entry(
+                    title=self.data[CONF_NAME],
+                    data=self.data,
+                )
 
         return self.async_show_form(
             step_id="timeout_opts",
@@ -275,4 +287,7 @@ class ICSCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data):
         """Import config from configuration.yaml."""
-        return self.async_create_entry(title="", data=import_data)
+        return self.async_create_entry(
+            title=import_data[CONF_NAME],
+            data=import_data,
+        )


### PR DESCRIPTION
Fixes #170
Description of change:

Set title when calling async_create_entry -- an empty string was used as a placeholder, and I didn't pay enough attention to notice it several months later when I came back to the code. :(  This also fixed an item in TODO.md.

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
