### PR TITLE
Switch to uv

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,34 +11,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@3
+        with:
+          version: "0.4.20"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version-file: "pyproject.toml"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements.test.txt
-          pip install -r requirements.dev.txt
+          uv sync --dev --extra tests
 
       - name: Run isort --check
         run: |
-          isort --check custom_components/ics_calendar tests
+          uv run isort --check custom_components/ics_calendar tests
 
       - name: Run black --check
         run: |
-          black --check custom_components/ics_calendar tests
+          uv run black --check custom_components/ics_calendar tests
 
       - name: Run flake8
         run: |
-          flake8
+          uv run flake8
 
       - name: Run pydocstyle
         run: |
-          pydocstyle -v custom_components/ics_calendar tests
+          uv run pydocstyle -v custom_components/ics_calendar tests
 
       - name: Run pylint
         run: |
-          pylint custom_components/ics_calendar
+          uv run pylint custom_components/ics_calendar

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@3
+        uses: astral-sh/setup-uv@v3
         with:
           version: "0.4.20"
 

--- a/.github/workflows/runtests.yaml
+++ b/.github/workflows/runtests.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@3
+        uses: astral-sh/setup-uv@v3
         with:
           version: "0.4.20"
 

--- a/.github/workflows/runtests.yaml
+++ b/.github/workflows/runtests.yaml
@@ -18,20 +18,23 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@3
+        with:
+          version: "0.4.20"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version-file: "pyproject.toml"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements.test.txt
+          uv sync --extra tests
 
       - name: Run pytest
         run: |
-          pytest tests/
+          uv run pytest tests/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+uv.lock

--- a/README.md
+++ b/README.md
@@ -156,17 +156,12 @@ This example will exclude any event whose summary or description includes "test"
 
 ## Development environment setup
 
+You should have uv installed.  Then run the following commands:
+
 ```shell
-$ python3 -m venv ./env
-$ ./env/bin/pip install --upgrade setuptools
-$ ./env/bin/pip install --upgrade wheel
-
-$ ./env/bin/pip install -r ./requirements.txt
-$ ./env/bin/pip install -r ./requirements.dev.txt
-$ ./env/bin/pip install -r ./requirements.test.txt
-
-$ source ./env/bin/activate
-
+$ uv sync --dev --extra tests
+$ source ./env/bin/activate # for CSH shells
+$ . ./env/bin/activate # for most other shells
 ```
 
 [![Buy me some pizza](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/qpunYPZx5)

--- a/custom_components/ics_calendar/manifest.json
+++ b/custom_components/ics_calendar/manifest.json
@@ -9,6 +9,6 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/franc6/ics_calendar/issues",
-    "requirements": ["ics>=0.7.2", "recurring_ical_events>=3.3.0", "icalendar>=5.0.13"],
+    "requirements": ["ics>=0.7.2", "recurring_ical_events>=3.3.2", "icalendar>=6.0.0"],
     "version": "5.0.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,40 @@
+[project]
+name = "ics_calendar"
+version = "5.0.4"
+readme = "README.md"
+requires-python = "==3.12"
+dependencies = [
+    'icalendar >= 6.0.0',
+    'python-dateutil >= 2.9.0.post0',
+    'pytz >= 2024.1',
+    'recurring_ical_events >= 3.3.2',
+    'ics >= 0.7.2',
+    'arrow'
+]
+
+[project.optional-dependencies]
+tests = [
+    'pytest',
+    'pytest-cov',
+    'pytest-homeassistant-custom-component>=0.13.172',
+    'pytest-helpers-namespace>=2021.12.29',
+    'pytest-asyncio',
+    'pytest-aiohttp',
+    'aiohttp_cors',
+    'aiotask_context'
+]
+
+[tool.uv]
+dev-dependencies = [
+    'black',
+    'isort',
+    'flake8',
+    'flake8-pyproject',
+    'pydocstyle',
+    'pylint',
+    'radon'
+]
+
 [tool.black]
 line-length = 79
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,0 @@
-black
-isort
-flake8
-flake8-pyproject
-pydocstyle
-pylint
-radon

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,8 +1,0 @@
-pytest
-pytest-cov
-pytest-homeassistant-custom-component>=0.13.172
-pytest-helpers-namespace>=2021.12.29
-pytest-asyncio
-pytest-aiohttp
-aiohttp_cors
-aiotask_context

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
-pytest-homeassistant-custom-component>=0.13.162
+pytest-homeassistant-custom-component>=0.13.172
 pytest-helpers-namespace>=2021.12.29
 pytest-asyncio
 pytest-aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-icalendar >= 5.0.13
+icalendar >= 6.0.0
 python-dateutil >= 2.9.0.post0
 pytz >= 2024.1
-recurring_ical_events >= 3.3.0
+recurring_ical_events >= 3.3.2
 ics >= 0.7.2
 arrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-icalendar >= 6.0.0
-python-dateutil >= 2.9.0.post0
-pytz >= 2024.1
-recurring_ical_events >= 3.3.2
-ics >= 0.7.2
-arrow

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -20,9 +20,12 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 @pytest.fixture(autouse=True, name="skip_notifications")
 def skip_notifications_fixture():
     """Skip notification calls."""
-    with patch(
-        "homeassistant.components.persistent_notification.async_create"
-    ), patch("homeassistant.components.persistent_notification.async_dismiss"):
+    with (
+        patch("homeassistant.components.persistent_notification.async_create"),
+        patch(
+            "homeassistant.components.persistent_notification.async_dismiss"
+        ),
+    ):
         yield
 
 
@@ -48,9 +51,12 @@ def mock_http(hass):
 @pytest.fixture(autouse=True)
 def mock_http_start_stop():
     """Fixture to avoid stop/start of http server."""
-    with patch(
-        "homeassistant.components.http.start_http_server_and_save_config"
-    ), patch("homeassistant.components.http.HomeAssistantHTTP.stop"):
+    with (
+        patch(
+            "homeassistant.components.http.start_http_server_and_save_config"
+        ),
+        patch("homeassistant.components.http.HomeAssistantHTTP.stop"),
+    ):
         yield
 
 


### PR DESCRIPTION
Description of change:

Switch scripts, github workflows, and documentation to use uv instead of pip, virtualenv, etc.  This is a switch made by HA, and was initially done here to help mimic a real HA environment, in case the switch was the cause of #174.  It was not, but uv seems to be a good choice, so the switch is made permanent.

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
