### PR TITLE
Fix #237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 5.1.4 2025/04/08
+## 5.1.4 2025/04/XX
 - Added Spanish translation, thanks @cvc90!
-- Added ability to use offsets in URL templates.
+- Added ability to use offsets in URL templates (fixed #239)
+- Fixed  #237
 
 ## 5.1.3 2025/02/13
 - Updated recurring_ical_events to latest for bug fixes and to prevent 2.5.0 from being used. Big thanks to @ccMatrix, @cookie050, and the many others who reported the problem and determined the correct fix!

--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -47,6 +47,7 @@ from .const import (
 )
 from .filter import Filter
 from .getparser import GetParser
+from .parserevent import ParserEvent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -218,7 +219,7 @@ class ICSCalendarEntity(CalendarEntity):
     async def async_update(self):
         """Get the current or next event."""
         await self.data.async_update()
-        self._event = self.data.event
+        self._event: CalendarEvent | None = self.data.event
         self._attr_extra_state_attributes = {
             "offset_reached": (
                 is_offset_reached(
@@ -309,7 +310,7 @@ class ICSCalendarData:  # pylint: disable=R0902
         :param end_date: The last starting date to consider
         :type end_date: datetime
         """
-        event_list = []
+        event_list: list[ParserEvent] = []
         if await self._calendar_data.download_calendar():
             _LOGGER.debug("%s: Setting calendar content", self.name)
             self.parser.set_content(self._calendar_data.get())
@@ -326,23 +327,27 @@ class ICSCalendarData:  # pylint: disable=R0902
                 self.name,
                 exc_info=True,
             )
-            event_list = []
+            event_list: list[ParserEvent] = []
 
         for event in event_list:
             event.summary = self._summary_prefix + event.summary
             if not event.summary:
                 event.summary = self._summary_default
+            # Since we skipped the validation code earlier, invoke it now,
+            # before passing the object outside this component
+            event.validate()
 
         return event_list
 
     async def async_update(self):
         """Get the current or next event."""
         _LOGGER.debug("%s: Update was called", self.name)
+        parser_event: ParserEvent | None = None
         if await self._calendar_data.download_calendar():
             _LOGGER.debug("%s: Setting calendar content", self.name)
             self.parser.set_content(self._calendar_data.get())
         try:
-            self.event = self.parser.get_current_event(
+            parser_event: ParserEvent | None = self.parser.get_current_event(
                 include_all_day=self.include_all_day,
                 now=hanow(),
                 days=self._days,
@@ -352,20 +357,24 @@ class ICSCalendarData:  # pylint: disable=R0902
             _LOGGER.error(
                 "update: %s: Failed to parse ICS!", self.name, exc_info=True
             )
-        if self.event is not None:
+        if parser_event is not None:
             _LOGGER.debug(
                 "%s: got event: %s; start: %s; end: %s; all_day: %s",
                 self.name,
-                self.event.summary,
-                self.event.start,
-                self.event.end,
-                self.event.all_day,
+                parser_event.summary,
+                parser_event.start,
+                parser_event.end,
+                parser_event.all_day,
             )
-            (summary, offset) = extract_offset(self.event.summary, OFFSET)
-            self.event.summary = self._summary_prefix + summary
-            if not self.event.summary:
-                self.event.summary = self._summary_default
+            (summary, offset) = extract_offset(parser_event.summary, OFFSET)
+            parser_event.summary = self._summary_prefix + summary
+            if not parser_event.summary:
+                parser_event.summary = self._summary_default
             self.offset = offset
+            # Invoke validation here, since it was skipped when creating the
+            # ParserEvent
+            parser_event.validate()
+            self.event: CalendarEvent = parser_event
             return True
 
         _LOGGER.debug("%s: No event found!", self.name)

--- a/custom_components/ics_calendar/filter.py
+++ b/custom_components/ics_calendar/filter.py
@@ -4,7 +4,7 @@ import re
 from ast import literal_eval
 from typing import List, Optional, Pattern
 
-from homeassistant.components.calendar import CalendarEvent
+from .parserevent import ParserEvent
 
 
 class Filter:
@@ -114,11 +114,11 @@ class Filter:
             add_event = self._is_included(summary, description)
         return add_event
 
-    def filter_event(self, event: CalendarEvent) -> bool:
+    def filter_event(self, event: ParserEvent) -> bool:
         """Check if the event should be included or not.
 
         :param event: The event to examine
-        :type event: CalendarEvent
+        :type event: ParserEvent
         :return: true if the event should be included, otherwise false
         :rtype: bool
         """

--- a/custom_components/ics_calendar/icalendarparser.py
+++ b/custom_components/ics_calendar/icalendarparser.py
@@ -3,9 +3,8 @@
 from datetime import datetime
 from typing import Optional
 
-from homeassistant.components.calendar import CalendarEvent
-
 from .filter import Filter
+from .parserevent import ParserEvent
 
 
 class ICalendarParser:
@@ -33,7 +32,7 @@ class ICalendarParser:
         end: datetime,
         include_all_day: bool,
         offset_hours: int = 0,
-    ) -> list[CalendarEvent]:
+    ) -> list[ParserEvent]:
         """Get a list of events.
 
         Gets the events from start to end, including or excluding all day
@@ -47,7 +46,7 @@ class ICalendarParser:
         :param offset_hours the number of hours to offset the event
         :type offset_hours int
         :returns a list of events, or an empty list
-        :rtype list[CalendarEvent]
+        :rtype list[ParserEvent]
         """
 
     def get_current_event(
@@ -56,7 +55,7 @@ class ICalendarParser:
         now: datetime,
         days: int,
         offset_hours: int = 0,
-    ) -> Optional[CalendarEvent]:
+    ) -> Optional[ParserEvent]:
         """Get the current or next event.
 
         Gets the current event, or the next upcoming event with in the
@@ -69,5 +68,5 @@ class ICalendarParser:
         :type days int
         :param offset_hours the number of hours to offset the event
         :type offset_hours int
-        :returns a CalendarEvent or None
+        :returns a ParserEvent or None
         """

--- a/custom_components/ics_calendar/parserevent.py
+++ b/custom_components/ics_calendar/parserevent.py
@@ -1,0 +1,20 @@
+"""Provide ParserEvent class."""
+
+import dataclasses
+
+from homeassistant.components.calendar import CalendarEvent
+
+
+@dataclasses.dataclass
+class ParserEvent(CalendarEvent):
+    """Class to represent CalendarEvent without validation."""
+
+    def validate(self) -> None:
+        """Invoke __post_init__ from CalendarEvent."""
+        return super().__post_init__()
+
+    def __post_init__(self) -> None:
+        """Don't do validation steps for this class."""
+        # This is necessary to prevent problems when creating events that don't
+        # have a summary. We'll add a summary after the event is created, not
+        # before, to reduce code repitition.

--- a/custom_components/ics_calendar/parsers/parser_ics.py
+++ b/custom_components/ics_calendar/parsers/parser_ics.py
@@ -5,11 +5,11 @@ from datetime import date, datetime, timedelta
 from typing import Optional, Union
 
 from arrow import Arrow, get as arrowget
-from homeassistant.components.calendar import CalendarEvent
 from ics import Calendar
 
 from ..filter import Filter
 from ..icalendarparser import ICalendarParser
+from ..parserevent import ParserEvent
 from ..utility import compare_event_dates
 
 
@@ -42,7 +42,7 @@ class ParserICS(ICalendarParser):
 
     def get_event_list(
         self, start, end, include_all_day: bool, offset_hours: int = 0
-    ) -> list[CalendarEvent]:
+    ) -> list[ParserEvent]:
         """Get a list of events.
 
         Gets the events from start to end, including or excluding all day
@@ -56,9 +56,9 @@ class ParserICS(ICalendarParser):
         :param offset_hours the number of hours to offset the event
         :type offset_hours int
         :returns a list of events, or an empty list
-        :rtype list[CalendarEvent]
+        :rtype list[ParserEvent]
         """
-        event_list: list[CalendarEvent] = []
+        event_list: list[ParserEvent] = []
 
         if self._calendar is not None:
             # ics 0.8 takes datetime not Arrow objects
@@ -76,7 +76,7 @@ class ParserICS(ICalendarParser):
                 #    summary = event.summary
                 # elif hasattr(event, "name"):
                 summary = event.name
-                calendar_event: CalendarEvent = CalendarEvent(
+                calendar_event: ParserEvent = ParserEvent(
                     summary=summary,
                     start=ParserICS.get_date(
                         event.begin, event.all_day, offset_hours
@@ -98,7 +98,7 @@ class ParserICS(ICalendarParser):
         now: datetime,
         days: int,
         offset_hours: int = 0,
-    ) -> Optional[CalendarEvent]:
+    ) -> Optional[ParserEvent]:
         """Get the current or next event.
 
         Gets the current event, or the next upcoming event with in the
@@ -111,7 +111,7 @@ class ParserICS(ICalendarParser):
         :type int
         :param offset_hours the number of hours to offset the event
         :type int
-        :returns a CalendarEvent or None
+        :returns a ParserEvent or None
         """
         if self._calendar is None:
             return None
@@ -145,7 +145,7 @@ class ParserICS(ICalendarParser):
         # summary = temp_event.summary
         # elif hasattr(event, "name"):
         summary = temp_event.name
-        return CalendarEvent(
+        return ParserEvent(
             summary=summary,
             start=ParserICS.get_date(
                 temp_event.begin, temp_event.all_day, offset_hours

--- a/custom_components/ics_calendar/parsers/parser_rie.py
+++ b/custom_components/ics_calendar/parsers/parser_rie.py
@@ -4,11 +4,11 @@ from datetime import date, datetime, timedelta
 from typing import Optional, Union
 
 import recurring_ical_events as rie
-from homeassistant.components.calendar import CalendarEvent
 from icalendar import Calendar
 
 from ..filter import Filter
 from ..icalendarparser import ICalendarParser
+from ..parserevent import ParserEvent
 from ..utility import compare_event_dates
 
 
@@ -46,7 +46,7 @@ class ParserRIE(ICalendarParser):
         end: datetime,
         include_all_day: bool,
         offset_hours: int = 0,
-    ) -> list[CalendarEvent]:
+    ) -> list[ParserEvent]:
         """Get a list of events.
 
         Gets the events from start to end, including or excluding all day
@@ -60,9 +60,9 @@ class ParserRIE(ICalendarParser):
         :param offset_hours the number of hours to offset the event
         :type offset_hours int
         :returns a list of events, or an empty list
-        :rtype list[CalendarEvent]
+        :rtype list[ParserEvent]
         """
-        event_list: list[CalendarEvent] = []
+        event_list: list[ParserEvent] = []
 
         if self._calendar is not None:
             for event in rie.of(self._calendar, skip_bad_series=True).between(
@@ -74,7 +74,7 @@ class ParserRIE(ICalendarParser):
                 if all_day and not include_all_day:
                     continue
 
-                calendar_event: CalendarEvent = CalendarEvent(
+                calendar_event: ParserEvent = ParserEvent(
                     summary=event.get("SUMMARY"),
                     start=start,
                     end=end,
@@ -92,7 +92,7 @@ class ParserRIE(ICalendarParser):
         now: datetime,
         days: int,
         offset_hours: int = 0,
-    ) -> Optional[CalendarEvent]:
+    ) -> Optional[ParserEvent]:
         """Get the current or next event.
 
         Gets the current event, or the next upcoming event with in the
@@ -105,7 +105,7 @@ class ParserRIE(ICalendarParser):
         :type int
         :param offset_hours the number of hours to offset the event
         :type offset_hours int
-        :returns a CalendarEvent or None
+        :returns a ParserEvent or None
         """
         if self._calendar is None:
             return None
@@ -140,7 +140,7 @@ class ParserRIE(ICalendarParser):
         if temp_event is None:
             return None
 
-        return CalendarEvent(
+        return ParserEvent(
             summary=temp_event.get("SUMMARY"),
             start=temp_start,
             end=temp_end,

--- a/tests/allday.ics.expected.json
+++ b/tests/allday.ics.expected.json
@@ -39,7 +39,7 @@
         "all_day": true,
         "summary": "7 All Day, 00:00:00 - 23:59:59, No Time Zone",
         "start": "2022-01-03",
-        "end": "2022-01-04"
+        "end": "2022-01-03"
     },
     {
         "all_day": true,

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -5,7 +5,6 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 from dateutil import parser as dtparser
-from homeassistant.components.calendar import CalendarEvent
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.template import DATE_STR_FORMAT
@@ -13,6 +12,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as hadt
 
 from custom_components.ics_calendar.const import DOMAIN
+from custom_components.ics_calendar.parserevent import ParserEvent
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -62,7 +62,7 @@ def mock_http_start_stop():
 
 def _mocked_event():
     """Provide fixture to mock a single event."""
-    return CalendarEvent(
+    return ParserEvent(
         summary="Test event",
         start=hadt.as_local(dtparser.parse("2022-01-03T00:00:00")),
         end=hadt.as_local(dtparser.parse("2022-01-03T05:00:00")),
@@ -73,7 +73,7 @@ def _mocked_event():
 
 def _mocked_event_no_summary():
     """Provide fixture to mock a single event."""
-    return CalendarEvent(
+    return ParserEvent(
         summary="",
         start=hadt.as_local(dtparser.parse("2022-01-03T00:00:00")),
         end=hadt.as_local(dtparser.parse("2022-01-03T05:00:00")),
@@ -85,21 +85,21 @@ def _mocked_event_no_summary():
 def _mocked_event_list():
     """Provide fixture to mock a list of events."""
     return [
-        CalendarEvent(
+        ParserEvent(
             summary="Test event 2",
             start=dtparser.parse("2022-01-04T00:00:00Z"),
             end=dtparser.parse("2022-01-04T05:00:00Z"),
             location="Test location",
             description="Test description",
         ),
-        CalendarEvent(
+        ParserEvent(
             summary="Test event",
             start=dtparser.parse("2022-01-03T00:00:00Z"),
             end=dtparser.parse("2022-01-03T05:00:00Z"),
             location="Test location",
             description="Test description",
         ),
-        CalendarEvent(
+        ParserEvent(
             summary="Test event 3",
             start=dtparser.parse("2022-01-05T00:00:00Z"),
             end=dtparser.parse("2022-01-05T05:00:00Z"),
@@ -112,21 +112,21 @@ def _mocked_event_list():
 def _mocked_event_list_no_summary():
     """Provide fixture to mock a list of events without summaries."""
     return [
-        CalendarEvent(
+        ParserEvent(
             summary="",
             start=dtparser.parse("2022-01-04T00:00:00Z"),
             end=dtparser.parse("2022-01-04T05:00:00Z"),
             location="Test location",
             description="Test description 2",
         ),
-        CalendarEvent(
+        ParserEvent(
             summary="",
             start=dtparser.parse("2022-01-03T00:00:00Z"),
             end=dtparser.parse("2022-01-03T05:00:00Z"),
             location="Test location",
             description="Test description",
         ),
-        CalendarEvent(
+        ParserEvent(
             summary="",
             start=dtparser.parse("2022-01-05T00:00:00Z"),
             end=dtparser.parse("2022-01-05T05:00:00Z"),
@@ -138,7 +138,7 @@ def _mocked_event_list_no_summary():
 
 def _mocked_event_allday():
     """Provide fixture to mock a single all day event."""
-    return CalendarEvent(
+    return ParserEvent(
         summary="Test event",
         start=dtparser.parse("2022-01-03").date(),
         end=dtparser.parse("2022-01-04").date(),

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -2,15 +2,15 @@
 
 import pytest
 from dateutil import parser as dtparser
-from homeassistant.components.calendar import CalendarEvent
 
 from custom_components.ics_calendar.filter import Filter
+from custom_components.ics_calendar.parserevent import ParserEvent
 
 
 @pytest.fixture()
-def calendar_event() -> CalendarEvent:
-    """Fixture to return a CalendarEvent."""
-    return CalendarEvent(
+def calendar_event() -> ParserEvent:
+    """Fixture to return a ParserEvent."""
+    return ParserEvent(
         summary="summary",
         start=dtparser.parse("2020-01-01T0:00:00").astimezone(),
         end=dtparser.parse("2020-01-01T0:00:00").astimezone(),
@@ -27,7 +27,7 @@ class TestFilter:
         filt = Filter("", "")
         assert filt.filter("summary", "description") is True
 
-    def test_filter_event_empty(self, calendar_event: CalendarEvent) -> None:
+    def test_filter_event_empty(self, calendar_event: ParserEvent) -> None:
         """Test that an empty filter works on an event."""
         filt = Filter("", "")
         assert filt.filter_event(calendar_event) is True


### PR DESCRIPTION
Fixes #237

Description of change:
Use an internal class, ParserEvent instead of CalendarEvent, since we create the internal events before they will pass the validation in CalendarEvent.__post_init__

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [X] formatstyle.sh reports no errors
- [X] All unit tests pass (test.sh)
- [X] Code coverage has not decreased (test.sh)
