### PR TITLE
Fix startup crash on Python 3.13 by lazy-loading ParserICS

### DIFF
--- a/custom_components/ics_calendar/getparser.py
+++ b/custom_components/ics_calendar/getparser.py
@@ -1,27 +1,28 @@
 """Provide GetParser class."""
 
+from __future__ import annotations
+
 from .icalendarparser import ICalendarParser
-from .parsers.parser_ics import ParserICS
 from .parsers.parser_rie import ParserRIE
 
 
 class GetParser:  # pylint: disable=R0903
-    """Provide get_parser to return an instance of ICalendarParser.
+    """Return an instance of the requested parser.
 
-    The class provides a static method , get_instace, to get a parser instance.
-    The non static methods allow this class to act as an "interface" for the
-    parser classes.
+    NOTE: ParserICS is imported lazily to avoid importing the optional `ics`
+    dependency at Home Assistant startup.
     """
 
     @staticmethod
     def get_parser(parser: str, *args) -> ICalendarParser | None:
         """Get an instance of the requested parser."""
-        # parser_cls = ICalendarParser.get_class(parser)
-        # if parser_cls is not None:
-        # return parser_cls(*args)
         if parser == "rie":
             return ParserRIE(*args)
+
         if parser == "ics":
+            # Lazy import to prevent startup crash if `ics`/`tatsu` combo is broken
+            from .parsers.parser_ics import ParserICS  # pylint: disable=import-outside-toplevel
+
             return ParserICS(*args)
 
         return None


### PR DESCRIPTION
Avoid eager import of ParserICS which pulls in the optional `ics` dependency at Home Assistant startup.

On Python 3.13 this causes an ImportError due to a tatsu compatibility issue, even when using the default `rie` parser.

This change makes the import lazy so the integration can start normally unless the user explicitly selects `parser: ics`.

Fixes #

Description of change:

## Formatting, testing, and code coverage
Please note your pull request won't be accepted if you haven't properly formatted your source code, and ensured the unit tests are appropriate.  Please note if you are not running on Windows, you can either run the scripts via a bash installation (like git-bash).

- [] formatstyle.sh reports no errors
- [] All unit tests pass (test.sh)
- [] Code coverage has not decreased (test.sh)
