### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/custom_components/ics_calendar/calendar.py
+++ b/custom_components/ics_calendar/calendar.py
@@ -345,7 +345,7 @@ class ICSCalendarData:  # pylint: disable=R0902
                 include_all_day=self.include_all_day,
                 offset_hours=self._offset_hours,
             )
-        except:  # pylint: disable=W0702
+        except Exception:  # pylint: disable=W0702
             _LOGGER.error(
                 "async_get_events: %s: Failed to parse ICS!",
                 self.name,
@@ -379,7 +379,7 @@ class ICSCalendarData:  # pylint: disable=R0902
                 days=self._days,
                 offset_hours=self._offset_hours,
             )
-        except:  # pylint: disable=W0702
+        except Exception:  # pylint: disable=W0702
             _LOGGER.error(
                 "update: %s: Failed to parse ICS!", self.name, exc_info=True
             )

--- a/custom_components/ics_calendar/calendardata.py
+++ b/custom_components/ics_calendar/calendardata.py
@@ -177,7 +177,7 @@ class CalendarData:  # pylint: disable=R0902
             self.logger.error(
                 "%s: Error decoding data from url: %s", self.name, self.url
             )
-        except:  # pylint: disable=W0702
+        except Exception:  # pylint: disable=W0702
             self.logger.error(
                 "%s: Failed to open url!", self.name, exc_info=True
             )


### PR DESCRIPTION
Replace bare 'except:' clauses with 'except Exception:' to avoid catching system signals like SystemExit, KeyboardInterrupt, and GeneratorExit.

Changes:
- calendar.py: Fix 2 bare excepts in async_get_events and async_update
- calendardata.py: Fix 1 bare except in _download_data

This follows Python best practices and prevents silently swallowing critical exceptions that should propagate.

— Sent via @AmSach bot